### PR TITLE
fix(a11y): accessible index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,8 +28,8 @@
 </head>
 <body>
   <div class="container">
-    <header>
-      <pre class="logo">
+    <header role="banner">
+      <pre class="logo" aria-hidden="true">
              oooo
              `888
     .ooooooo  888  oooo
@@ -40,12 +40,12 @@
         `Y8b
    d8P   d88
    `Y88888P'
+     </pre>
 
-<span class="wide">greenkeeper.io</span>
-      </pre>
+    <pre class="logo"><span class="wide">greenkeeper.io</span></pre>
       <span>Your software, up to date, all&nbsp;the&nbsp;time.</span>
     </header>
-    <div class="main">
+    <div class="main" role="main">
       <h1>Always up-to-date dependencies, zero hassle</h1>
       <p>Tired of keeping all your dependencies up to date? Uncomfortable with just pinning them? Yup, so are we. So we made <strong>greenkeeper: it knows when your dependencies got updated and simply sends you a pull request with the new package.json</strong>. If you've got continuous integration tests, they'll run, and you can keep your software up to date with a single click on GitHub's merge button.</p>
 
@@ -99,16 +99,20 @@
       <p>No problem, we're here. <a href="mailto:hi@greenkeeper.io">Send us an email</a> or get in touch via twitter <a href="http://twitter.com/greenkeeperio" title="Please don't say this with Mario's voice…">@greenkeeperio</a>.</p>
 
       <span class="hr"></span>
-      <ul class="nav">
-        <li><a href="impressum.html">Impressum</a></li>
-        <li><a href="terms-of-service.html">Terms of Service</a></li>
-        <li><a href="privacy-policy.html">Privacy Policy</a></li>
-      </ul>
+      <nav role="navigation">
+        <ul class="nav">
+          <li><a href="impressum.html">Impressum</a></li>
+          <li><a href="terms-of-service.html">Terms of Service</a></li>
+          <li><a href="privacy-policy.html">Privacy Policy</a></li>
+        </ul>
+      </nav>
       <span class="hr"></span>
-      <p>greenkeeper.io is best used together with <a href="http://git.io/semantic-release">semantic-release: fully automated package publishing</a>.</p>
-      <p>Brought to you by the people behind <a href="http://hood.ie">Hoodie</a>. We're re-inventing web app development. Take a look!</p>
-      <p>.io domain? — <a href="http://www.chagossupport.org.uk" title="chagos-support">Yes, we support Chagos!</a></p>
-      <p>&copy; 2015 <a href="http://neighbourhood.ie">The Neighbourhoodie Software GmbH</a></p>
+      <footer role='contentinfo'>
+        <p>greenkeeper.io is best used together with <a href="http://git.io/semantic-release">semantic-release: fully automated package publishing</a>.</p>
+        <p>Brought to you by the people behind <a href="http://hood.ie">Hoodie</a>. We're re-inventing web app development. Take a look!</p>
+        <p>.io domain? — <a href="http://www.chagossupport.org.uk" title="chagos-support">Yes, we support Chagos!</a></p>
+        <p>&copy; 2015 <a href="http://neighbourhood.ie">The Neighbourhoodie Software GmbH</a></p>
+      </footer>
     </div>
   </div>
 

--- a/main.css
+++ b/main.css
@@ -120,7 +120,7 @@ ul:not(.nav) li:before{
   margin-right: 0.5em;
 }
 
-.main > ul {
+.main > ul, .main > nav {
   border-left: 2px solid #31B731;
   margin-left: 0.25em;
 }


### PR DESCRIPTION
Have added ARIA roles and semantic HTML to index.html.

The main problem that we need to discuss is the logo.
Without my changes, the logo, when read by screenreaders will say "oooo8888dddddd8s89898e8e0r" etc. Which takes a minute and is very inaccessible. So, I added 'aria-hidden=true' which should hide the logo from screenreaders. _However_, this is not supported by all browsers so it's possible that some people will hear the long ASCII text.

My suggestions would be to use a logo image instead, which is easily ignored.

Once you've come to a decision on that, the rest of the HTML pages will be easy to do.

🌟
