### PR TITLE
fix(a11y): context for homepage link

### DIFF
--- a/impressum.html
+++ b/impressum.html
@@ -41,8 +41,8 @@
    d8P   d88
    `Y88888P'
         </pre>
+        <pre class="logo"><span class="wide">greenkeeper.io</span></pre>
       </a>
-      <pre class="logo"><span class="wide">greenkeeper.io</span></pre>
       <span>Your software, up to date, all&nbsp;the&nbsp;time.</span>
     </header>
     <div class="main" role="main">

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -41,8 +41,8 @@
    d8P   d88
    `Y88888P'
         </pre>
+        <pre class="logo"><span class="wide">greenkeeper.io</span></pre>
       </a>
-      <pre class="logo"><span class="wide">greenkeeper.io</span></pre>
       <span>Your software, up to date, all&nbsp;the&nbsp;time.</span>
     </header>
     <div class="main" role="main">

--- a/terms-of-service.html
+++ b/terms-of-service.html
@@ -41,8 +41,8 @@
    d8P   d88
    `Y88888P'
         </pre>
+        <pre class="logo"><span class="wide">greenkeeper.io</span></pre>
       </a>
-      <pre class="logo"><span class="wide">greenkeeper.io</span></pre>
       <span>Your software, up to date, all&nbsp;the&nbsp;time.</span>
     </header>
     <div class="main" role="main">

--- a/thanks-for-confirming-your-payment.html
+++ b/thanks-for-confirming-your-payment.html
@@ -41,8 +41,8 @@
    d8P   d88
    `Y88888P'
         </pre>
+        <pre class="logo"><span class="wide">greenkeeper.io</span></pre>
       </a>
-      <pre class="logo"><span class="wide">greenkeeper.io</span></pre>
       <span>Your software, up to date, all&nbsp;the&nbsp;time.</span>
     </header>
     <div class="main" role="main">

--- a/thanks-for-signing-up.html
+++ b/thanks-for-signing-up.html
@@ -41,8 +41,8 @@
    d8P   d88
    `Y88888P'
         </pre>
+        <pre class="logo"><span class="wide">greenkeeper.io</span></pre>
       </a>
-      <pre class="logo"><span class="wide">greenkeeper.io</span></pre>
       <span>Your software, up to date, all&nbsp;the&nbsp;time.</span>
     </header>
     <div class="main" role="main">


### PR DESCRIPTION
My brain made a mistake and moved this text out of the link, but without this text inside the link a screenreader just reads it as ‘slash’.
