### PR TITLE
fix: npm rebranded On-Site to Enterprise

### DIFF
--- a/app/index.ejs
+++ b/app/index.ejs
@@ -189,7 +189,7 @@
 <div class="single full-height enterprise">
   <section>
     <h2><span class="green">05</span> Enterprise plan</h2>
-    <p>You’re using <a href="https://enterprise.github.com/home">GitHub Enterprise</a> and/or <a href="https://www.npmjs.com/onsite">npm On-Site</a>? No problem, we support those too.</p>
+    <p>You’re using <a href="https://enterprise.github.com/home">GitHub Enterprise</a> and/or <a href="https://www.npmjs.com/enterprise">npm Enterprise</a>? No problem, we support those too.</p>
     <p><a href="mailto:enterprise@greenkeeper.io">Please get in touch with us</a> we’ll get you set up in no time.</p>
   </section>
 </div>


### PR DESCRIPTION
Enterprise → On-Site → Enterprise

We (at npm) have sufficiently confused enough people. Enterprise it is. 👍 

<img width="780" alt="screen shot 2016-05-09 at 4 58 22 pm" src="https://cloud.githubusercontent.com/assets/1929625/15127995/4cb7ec5a-1607-11e6-9245-abe00073755f.png">
