### PR TITLE
chore: deploy from source to master, use org gh-page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ deploy:
   script: npm run deploy
   skip_cleanup: true
   on:
-    branch: master
+    branch: source

--- a/app/partials/_footer.ejs
+++ b/app/partials/_footer.ejs
@@ -18,7 +18,7 @@
 
 <footer role="contentinfo">
   <p>greenkeeper.io is best used together with our open source library <a href="http://git.io/semantic-release">semantic-release: fully automated package publishing</a>.</p>
-  <p><a href="https://github.com/greenkeeperio/greenkeeper">The Greenkeeper CLI is Open Source on GitHub</a>. So is <a href="https://github.com/greenkeeperio/website">this website</a>. Thank you for your future contributions!</p>
+  <p><a href="https://github.com/greenkeeperio/greenkeeper">The Greenkeeper CLI is Open Source on GitHub</a>. So is <a href="https://github.com/greenkeeperio/greenkeeperio.github.io">this website</a>. Thank you for your future contributions!</p>
   <p>Brought to you by the people behind <a href="http://hood.ie">Hoodie</a>. We’re re-inventing web app development. Take a look!</p>
   <p>.io domain? — <a href="http://www.chagossupport.org.uk" title="chagos-support">Yes, we support Chagos!</a></p>
   <p>© 2016 <a href="http://neighbourhood.ie">The Neighbourhoodie Software GmbH</a></p>

--- a/deploy.js
+++ b/deploy.js
@@ -4,6 +4,7 @@ var repo = require('url').parse(require('./package.json').repository.url)
 repo.auth = process.env.GH_TOKEN
 
 require('gh-pages').publish(require('path').join(__dirname, 'www'), {
+  branch: 'master',
   repo: repo.format(),
   silent: true,
   user: {


### PR DESCRIPTION
This PR changes deploy scripts so they happen on the `source` branch and deploy to `master`.

The idea is to rename this repo from `website` to `greenkeeperio.github.io` before merging. When doing this GitHub will use the master branch instead of the gh-pages branch and this will serve as our org-wide page.

This means we could create a `blog` repo, publish gh-pages from there and it ends up as `https://greenkeeperio.github.io/blog` or in our case `https://greenkeeper.io/blog`.
Using a custom domain on these repos still works, so then greenkeeper.io/app forwards to app.greenkeeper.io again.

@christophwitzko Could you review that this doesn't end in Cloudflare SSL snafu?

