### PR TITLE
Small typo fixes

### DIFF
--- a/app/index.ejs
+++ b/app/index.ejs
@@ -111,7 +111,7 @@
       <li>Staying on top of dependency updates is a lot of cognitive overhead: your code depends on modules that depend on modules. It’s modules all the way down. Stuff gets updated all the time. It’ll either annoy you, or you’ll miss it.</li>
       <li><strong>Version pinning</strong> would save you the hassle, but you’ll miss bugfixes and new features, and when you do have to update everything in the future, it’ll probably be a huge mess. So let’s not pin.</li>
       <li><strong>Version ranges</strong> would be nice, but suffer from the fact that SemVer has … room for interpretation. Module authors simply make mistakes from time to time.</li>
-      <li>You could do all the updates and testing by hand, all the time. But that’s dull, repetetive work, which is why, let’s be honest, barely anyone actually does it.</li>
+      <li>You could do all the updates and testing by hand, all the time. But that’s dull, repetitive work, which is why, let’s be honest, barely anyone actually does it.</li>
     </ul>
   </section>
 </div>

--- a/app/privacy-policy.ejs
+++ b/app/privacy-policy.ejs
@@ -16,7 +16,7 @@
 
     <h2>Log Data</h2>
 
-    <p>greenkeeper.io collects certain request and transaction data in log files. This data is used for quality assurance, bug fixing, statistics and the securing of the system. greenkeeper.io can publish statistics publicly under the provision that no personal data is associated with them. greenkeeper.io collects ip addresses, referrers, browser technolgy information and access times for the outlined reasons.</p>
+    <p>greenkeeper.io collects certain request and transaction data in log files. This data is used for quality assurance, bug fixing, statistics and the securing of the system. greenkeeper.io can publish statistics publicly under the provision that no personal data is associated with them. greenkeeper.io collects ip addresses, referrers, browser technology information and access times for the outlined reasons.</p>
 
     <p>greenkeeper.io relies on Intercom to collect usage statistics and to allow direct, in-app customer support. Intercom’s terms of service (<a href="http://docs.intercom.io/terms" title="Intercom Docs">http://docs.intercom.io/terms</a>) and privacy policy (<a href="http://docs.intercom.io/privacy" title="Intercom Docs">http://docs.intercom.io/privacy</a>) apply.
     </p>
@@ -51,7 +51,7 @@
 
     <h3>Changes</h3>
 
-    <p>greenkeeper.io reserves the right to update this privacy policy at any time. The latest version is always availalble at <a href="http://greenkeeper.io/privacy-policy.html">http://greenkeeper.io/privacy-policy.html</a>.</p>
+    <p>greenkeeper.io reserves the right to update this privacy policy at any time. The latest version is always available at <a href="http://greenkeeper.io/privacy-policy.html">http://greenkeeper.io/privacy-policy.html</a>.</p>
 
     <h3>Objection, Revocation, Disclosure, Correction, Inhibition, Deletion</h3>
 


### PR DESCRIPTION
Fix small typos on landing page and privacy policy.

(ran `app/` directory through a quick pass of spellcheck)

Looking forward to using this on a project; thanks for providing the service!

Apparently similar PRs have come up before and been closed by the original authors. I'm in no hurry, so I'll just leave this here in case it's useful.