### PR TITLE
BaseT mention in monorepo dependencies

### DIFF
--- a/app/docs.ejs
+++ b/app/docs.ejs
@@ -227,7 +227,7 @@
     <a href="#top">Back to top</a>
 
     <h2><a href="#monorepo-dependencies" id="monorepo-dependencies">Using Greenkeeper with monorepo dependencies</a></h2>
-    <p>Greenkeeper will group releases from some of the more popular monorepo dependencies together, at time of writing these are <a href="https://github.com/angular/angular">Angular</a>, <a href="https://github.com/babel/babel">Babel</a>, <a href="https://github.com/facebook/jest">Jest</a>, <a href="https://github.com/pouchdb/pouchdb">PouchDB</a>, <a href="https://github.com/facebook/react">React</a> and <a href="https://github.com/storybooks/storybook">Storybook</a>.</p>
+    <p>Greenkeeper will group releases from some of the more popular monorepo dependencies together, at time of writing these are <a href="https://github.com/angular/angular">Angular</a>, <a href="https://github.com/babel/babel">Babel</a>, <a href="https://github.com/Igmat/baset">BaseT</a>, <a href="https://github.com/facebook/jest">Jest</a>, <a href="https://github.com/pouchdb/pouchdb">PouchDB</a>, <a href="https://github.com/facebook/react">React</a> and <a href="https://github.com/storybooks/storybook">Storybook</a>.</p>
     <p>You can view the release groups and also submit changes and additions to the <a href="https://github.com/greenkeeperio/greenkeeper/blob/master/utils/monorepo-definitions.js">monorepo release definitions file</a> in the Greenkeeper GitHub repository.</p>
     <p><strong>Note that we only support monorepo releases in which all modules contained in a single release have the same version number</strong>, this is what Lerna calls <a href="https://github.com/lerna/lerna#fixedlocked-mode-default">Fixed or Locked Mode</a>, which is their default.</p>
     <a href="#top">Back to top</a>


### PR DESCRIPTION
Since [BaseT](https://github.com/Igmat/baset) was added to monorepo definitions in [this PR](https://github.com/greenkeeperio/greenkeeper/pull/793) it probably worth to mention it in docs, where other monorepo dependencies are listed. 