### PR TITLE
docs(locked-monorepo): removed outdated note about only supporting fi…

### DIFF
--- a/app/de/dokumentation.ejs
+++ b/app/de/dokumentation.ejs
@@ -233,7 +233,6 @@
     <h2><a href="#monorepo-dependencies" id="monorepo-dependencies">Greenkeeper mit Monorepo-Dependencies verwenden</a></h2>
     <p>Greenkeeper wird Versionsaktualisierungen von Modulen aus populären Dependencies, die selber die Monorepos sind, in Pull Requests und Issues gruppieren, damit Sie weniger Arbeit haben. Dies sind zum Beispiel <a href="https://github.com/angular/angular">Angular</a>, <a href="https://github.com/babel/babel">Babel</a>, <a href="https://github.com/Igmat/baset">BaseT</a>, <a href="https://github.com/facebook/jest">Jest</a>, <a href="https://github.com/pouchdb/pouchdb">PouchDB</a>, <a href="https://github.com/facebook/react">React</a> und <a href="https://github.com/storybooks/storybook">Storybook</a>.</p>
     <p>Sie können die existierenden Gruppierungen in dem <a href="https://github.com/greenkeeperio/monorepo-definitions">monorepo release definitions-Modul</a> einsehen. Dort können Sie auch neue Gruppierungen hinzufügen oder die bestehenden verändern.</p>
-    <p><strong>Wir unterstützen nur Monorepo-Releases, bei denen alle beinhalteten Module in einem Release die gleiche Versionsnummer haben.</strong>. Bei Lerna ist dies der Normfall und wird <a href="https://github.com/lerna/lerna#fixedlocked-mode-default">Fixed or Locked Mode</a> genannt.</p>
     <a href="#top">Zum Seitenanfang</a>
 
     <h2><a href="#ignoring-dependencies" id="ignoring-dependencies">Einzelne Dependency Updates ignorieren</a></h2>

--- a/app/docs.ejs
+++ b/app/docs.ejs
@@ -231,7 +231,6 @@
     <h2><a href="#monorepo-dependencies" id="monorepo-dependencies">Using Greenkeeper with monorepo dependencies</a></h2>
     <p>Greenkeeper will group releases from some of the more popular monorepo dependencies together, at time of writing these are <a href="https://github.com/angular/angular">Angular</a>, <a href="https://github.com/babel/babel">Babel</a>, <a href="https://github.com/Igmat/baset">BaseT</a>, <a href="https://github.com/facebook/jest">Jest</a>, <a href="https://github.com/pouchdb/pouchdb">PouchDB</a>, <a href="https://github.com/facebook/react">React</a> and <a href="https://github.com/storybooks/storybook">Storybook</a>.</p>
     <p>You can view the release groups and also submit changes and additions to the <a href="https://github.com/greenkeeperio/monorepo-definitions">monorepo release definitions module</a> on GitHub.</p>
-    <p><strong>Note that we only support monorepo releases in which all modules contained in a single release have the same version number</strong>, this is what Lerna calls <a href="https://github.com/lerna/lerna#fixedlocked-mode-default">Fixed or Locked Mode</a>, which is their default.</p>
     <a href="#top">Back to top</a>
 
     <h2><a href="#ignoring-dependencies" id="ignoring-dependencies">Ignoring certain dependency’s updates</a></h2>


### PR DESCRIPTION
…xed/locked monorepos

this seems to be outdated, at least for PRs, and has caused confusion for those wanting to submit new definitions, such as https://github.com/greenkeeperio/monorepo-definitions/pull/24